### PR TITLE
Build without precompiled UI by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,17 +1,3 @@
-[root]
-name = "wasm"
-version = "0.1.0"
-dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-bigint 0.1.3",
- "ethcore-logger 1.9.0",
- "ethcore-util 1.9.0",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm 0.1.0",
- "wasm-utils 0.1.0 (git+https://github.com/paritytech/wasm-utils)",
-]
-
 [[package]]
 name = "adler32"
 version = "1.0.2"
@@ -2209,8 +2195,6 @@ version = "1.9.0"
 dependencies = [
  "parity-ui-dev 1.9.0",
  "parity-ui-old-dev 1.9.0",
- "parity-ui-old-precompiled 1.8.0 (git+https://github.com/paritytech/js-precompiled.git?branch=v1)",
- "parity-ui-precompiled 1.9.0 (git+https://github.com/paritytech/js-precompiled.git)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2224,22 +2208,6 @@ dependencies = [
 [[package]]
 name = "parity-ui-old-dev"
 version = "1.9.0"
-dependencies = [
- "parity-dapps-glue 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-ui-old-precompiled"
-version = "1.8.0"
-source = "git+https://github.com/paritytech/js-precompiled.git?branch=v1#94b0a89aac7eb5ddfdb53cd9bb039da6fdbf7583"
-dependencies = [
- "parity-dapps-glue 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-ui-precompiled"
-version = "1.9.0"
-source = "git+https://github.com/paritytech/js-precompiled.git#1626d64235241e75c531eece004a4923d9d4fcc6"
 dependencies = [
  "parity-dapps-glue 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3422,6 +3390,20 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasm"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcore-bigint 0.1.3",
+ "ethcore-logger 1.9.0",
+ "ethcore-util 1.9.0",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
+ "wasm-utils 0.1.0 (git+https://github.com/paritytech/wasm-utils)",
+]
+
+[[package]]
 name = "wasm-utils"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/wasm-utils#6a39db802eb6b67a0c4e5cf50741f965e217335a"
@@ -3644,8 +3626,6 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parity-dapps-glue 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "261c025c67ba416e9fe63aa9b3236520ce3c74cfbe43590c9cdcec4ccc8180e4"
 "checksum parity-tokio-ipc 0.1.5 (git+https://github.com/nikvolf/parity-tokio-ipc)" = "<none>"
-"checksum parity-ui-old-precompiled 1.8.0 (git+https://github.com/paritytech/js-precompiled.git?branch=v1)" = "<none>"
-"checksum parity-ui-precompiled 1.9.0 (git+https://github.com/paritytech/js-precompiled.git)" = "<none>"
 "checksum parity-wasm 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4502e18417d96bd8e72fca9ea4cc18f4d80288ff565582d10aefe86f18b4fc3"
 "checksum parity-wordlist 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81451bfab101d186f8fc4a0aa13cb5539b31b02c4ed96425a0842e2a413daba6"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,14 +82,10 @@ winapi = "0.2"
 daemonize = "0.2"
 
 [features]
-default = ["ui-precompiled"]
+default = ["ui"]
 ui = [
 	"ui-enabled",
 	"parity-dapps/ui",
-]
-ui-precompiled = [
-	"ui-enabled",
-	"parity-dapps/ui-precompiled",
 ]
 ui-enabled = ["dapps"]
 dapps = ["parity-dapps"]

--- a/dapps/Cargo.toml
+++ b/dapps/Cargo.toml
@@ -48,4 +48,3 @@ ethcore-devtools = { path = "../devtools" }
 dev = ["clippy", "ethcore-util/dev"]
 
 ui = ["parity-ui/no-precompiled-js"]
-ui-precompiled = ["parity-ui/use-precompiled-js"]

--- a/dapps/ui/Cargo.toml
+++ b/dapps/ui/Cargo.toml
@@ -13,9 +13,6 @@ rustc_version = "0.1"
 parity-ui-dev = { path = "../../js", optional = true }
 parity-ui-old-dev = { path = "../../js-old", optional = true }
 # This is managed by the js/scripts/release.sh script on CI - keep it in a single line
-parity-ui-old-precompiled = { git = "https://github.com/paritytech/js-precompiled.git", optional = true, branch = "v1" }
-parity-ui-precompiled = { git = "https://github.com/paritytech/js-precompiled.git", optional = true, branch = "master" }
 
 [features]
 no-precompiled-js = ["parity-ui-dev", "parity-ui-old-dev"]
-use-precompiled-js = ["parity-ui-precompiled", "parity-ui-old-precompiled"]

--- a/js-old/package-lock.json
+++ b/js-old/package-lock.json
@@ -2170,7 +2170,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true,
       "requires": {
         "core-js": "2.4.1",
         "regenerator-runtime": "0.10.5"
@@ -2179,8 +2178,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },
@@ -3302,8 +3300,7 @@
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4358,7 +4355,7 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.5.5",
+      "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
       "integrity": "sha1-ycYKSKRu5FL7MqccMXuV5aofyz0=",
       "dev": true
@@ -4399,7 +4396,7 @@
       "integrity": "sha1-NxlPWoXBKuQ4QpOVeZ7Ee0O8RT8=",
       "dev": true,
       "requires": {
-        "ejs": "2.5.5",
+        "ejs": "1.0.0",
         "through": "2.3.8"
       }
     },
@@ -11139,24 +11136,8 @@
     "react-inspector": {
       "version": "github:paritytech/react-inspector#73b5214261a5131821eb9088f58d7e5f31210c23",
       "requires": {
-        "babel-runtime": "6.26.0",
+        "babel-runtime": "6.23.0",
         "is-dom": "1.0.9"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-        }
       }
     },
     "react-intl": {


### PR DESCRIPTION
Removes the option to build using the (defunct here) precompiled UI (Solves #3). Building the binary with regular `cargo build --release` should now work.