### PR TITLE
"status" field fix

### DIFF
--- a/ethcore/res/ethereum/tobalaba.json
+++ b/ethcore/res/ethereum/tobalaba.json
@@ -18,7 +18,6 @@
         "networkID": "0x62121",
 	"wasmActivationTransition": 4000000,
 	"eip658Transition": 4600000
-
     },
     "genesis": {
         "seal": {

--- a/ethcore/res/ethereum/tobalaba.json
+++ b/ethcore/res/ethereum/tobalaba.json
@@ -16,7 +16,9 @@
         "gasLimitBoundDivisor": "0x400",
         "minGasLimit": "0x1388",
         "networkID": "0x62121",
-		"wasmActivationTransition": 4000000
+	"wasmActivationTransition": 4000000,
+	"eip658Transition": 4600000
+
     },
     "genesis": {
         "seal": {


### PR DESCRIPTION
#14 issue fix, requires an update of parameters in genesis json on authority clients and therefore a fork.
Baiscally update of the tobalaba.json accross the validators, prior to proposed fork.

Since the avg block time varies a lot lately (3s-7s). I made an automated [spreadsheet](https://docs.google.com/spreadsheets/d/1pnMh6F-itsjJoiTP9w1KzKPlgqEoAnXXlR6JZ-3S6MM/edit?usp=sharing) to have an idea of a possible deadline for necessary updates. 

Block 4600000 (as for today) is supposed to be "mined" on 31st of May. 

